### PR TITLE
Add SwH

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,7 @@ contracts – best practices to adopt](https://www.lfenergy.org/wp-content/uploa
 
 #### Code Hosting
 
+* [Software Heritage](https://www.softwareheritage.org/) - The universal software [archive](https://archive.softwareheritage.org/)
 * [GitHub](https://github.com) - Largest code hosting site
 * [Scaling from 2,000 to 25,000 engineers on GitHub at Microsoft](https://jeffwilcox.blog/2019/06/scaling-25k/) - Detailed report about how to scale an organization on GitHub with pointers to tools and best practices
 * [GitLab](https://gitlab.com) - Code hosting site whose code is available as open source under an open core model


### PR DESCRIPTION
Added SwH as the universal software archive in the code hosting section.